### PR TITLE
feat(maintenance): optional public 503 and an editable banner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,8 @@ jobs:
       # run no build step), so the autoloader is present straight from checkout.
       - name: Params typed accessors
         run: php tests/params-typed-accessors.php
+      - name: Maintenance mode helpers
+        run: php tests/maintenance-mode.php
       - name: Rewrite param decode
         run: php tests/rewrite-param-decode.php
       - name: Rewrite route match

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ most of them do not use — so it now goes in the same place as any other third-
   `after_delete_category` to pair with the existing `delete_category`. Each `before_` hook
   runs before the delete's transaction opens and each `after_` hook only once it has
   committed, so a plugin's own database work is never rolled back with a failed delete.
+- **Maintenance mode can stay online.** Tools → Maintenance still drops a `.maintenance`
+  file, and that still takes the public site to HTTP 503 unless you uncheck **Block the
+  public site**. Unchecked, visitors keep using the site and see a banner whose text you
+  edit on the same screen. The 503 page uses the same text. Signed-in admins are never
+  locked out. Command-line cron (`php index.php -p cron`) is not served a 503 either, so
+  scheduled jobs still run while the public site is down. Installs that have never saved
+  the new checkbox keep today's lockout.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ most of them do not use — so it now goes in the same place as any other third-
   edit on the same screen. The 503 page uses the same text. Signed-in admins are never
   locked out. Command-line cron (`php index.php -p cron`) is not served a 503 either, so
   scheduled jobs still run while the public site is down. Installs that have never saved
-  the new checkbox keep today's lockout.
+  the new checkbox keep today's lockout. The banner is printed on the `footer` hook
+  (inside `<body>`), not `header` (`<head>`), so third-party themes style it instead of
+  painting an unstyled bar above the fold.
 
 ### Breaking
 

--- a/index.php
+++ b/index.php
@@ -47,12 +47,24 @@ if (CLI) {
 }
 
 if (file_exists(ABS_PATH . '.maintenance')) {
-    if (osc_is_admin_user_logged_in()) {
-        define('__OSC_MAINTENANCE__', true);
-    } else {
+    // Default is a public 503 (same as before this option existed). Unchecking
+    // lockout in Tools → Maintenance leaves the site up and shows a banner.
+    // CLI is never 503'd: `php index.php -p cron` must still run while the
+    // public site is down. Admins always get through.
+    if (osc_maintenance_should_lockout_request(
+        true,
+        osc_maintenance_lockout_enabled(),
+        osc_is_admin_user_logged_in(),
+        CLI
+    )) {
         header('HTTP/1.1 503 Service Temporarily Unavailable');
         header('Status: 503 Service Temporarily Unavailable');
         header('Retry-After: 900');
+
+        $maintenanceMessage = osc_maintenance_visitor_message();
+        if (!defined('OSC_MAINTENANCE_MESSAGE')) {
+            define('OSC_MAINTENANCE_MESSAGE', $maintenanceMessage);
+        }
 
         if (file_exists(WebThemes::newInstance()->getCurrentThemePath() . 'maintenance.php')) {
             osc_current_web_theme_path('maintenance.php');
@@ -63,10 +75,7 @@ if (file_exists(ABS_PATH . '.maintenance')) {
 
         osc_die(
             sprintf(__('Maintenance &raquo; %s'), osc_page_title()),
-            sprintf(
-                __('%s is undergoing maintenance right now. We\'re making some improvements and will be back shortly — thanks for your patience.'),
-                osc_page_title()
-            ),
+            nl2br(osc_esc_html($maintenanceMessage), false),
             array(
                 'heading'   => __('We\'ll be right back'),
                 'tone'      => 'info',
@@ -76,6 +85,8 @@ if (file_exists(ABS_PATH . '.maintenance')) {
                 'brandName' => osc_page_title(),
             )
         );
+    } elseif (!CLI) {
+        define('__OSC_MAINTENANCE__', true);
     }
 }
 

--- a/oc-admin/themes/modern/tools/maintenance.php
+++ b/oc-admin/themes/modern/tools/maintenance.php
@@ -14,6 +14,10 @@
  */
 
 $maintenance = file_exists(osc_base_path() . '.maintenance');
+$lockout     = osc_maintenance_lockout_enabled();
+$message     = osc_sanitize_maintenance_message(
+    (string)osc_get_preference(OSC_MAINTENANCE_PREF_MESSAGE, OSC_MAINTENANCE_PREF_SECTION)
+);
 
 /**
  * @return string
@@ -27,20 +31,18 @@ function render_offset()
 osc_admin_page(array(
     'section' => __('Tools'),
     'title'   => __('Maintenance'),
-    'help'    => __('Show a "Site in maintenance mode" message to your users while you\'re updating your site or modifying its configuration.'),
+    'help'    => __('Put a banner on the site while you work, or take the public site down with HTTP 503. Signed-in admins always stay in.'),
 ));
 
 osc_current_admin_theme_path('parts/header.php'); ?>
 <div id="backup-setting">
-    <!-- settings form -->
     <div id="backup-settings">
         <?php osc_admin_page_head(__('Maintenance')); ?>
         <form>
             <fieldset>
                 <div class="form-horizontal">
                     <div class="form-row">
-                        <?php _e("While in maintenance mode, users can't access your website. Useful if you need to "
-                                 . "make changes on your website. Use the following button to toggle maintenance mode ON/OFF."); ?>
+                        <?php _e('Maintenance mode is switched by a <code>.maintenance</code> file in the install root. While it is on, signed-in admins can still use the site. Everyone else either sees the banner below, or (if lockout is on) an HTTP 503 page.'); ?>
                         <div class="<?php echo $maintenance ? 'callout-danger' : 'callout-success'; ?>">
                             <?php printf(__('Maintenance mode is: <strong>%s</strong>'),
                                 ($maintenance ? __('ON') : __('OFF'))); ?>
@@ -58,7 +60,38 @@ osc_current_admin_theme_path('parts/header.php'); ?>
                 </div>
             </fieldset>
         </form>
+
+        <form method="post" action="<?php echo osc_admin_base_url(true); ?>">
+            <input type="hidden" name="page" value="tools"/>
+            <input type="hidden" name="action" value="maintenance"/>
+            <input type="hidden" name="mode" value="save"/>
+            <fieldset>
+                <div class="form-horizontal">
+                    <div class="form-row">
+                        <div class="form-label-checkbox">
+                            <input type="checkbox" id="maintenance_lockout" name="maintenance_lockout" value="1"
+                                <?php echo $lockout ? 'checked="checked"' : ''; ?> />
+                            <label for="maintenance_lockout"><?php _e('Block the public site (HTTP 503)'); ?></label>
+                        </div>
+                        <div class="help-box">
+                            <?php _e('Checked is the historical behaviour: visitors cannot use the site and receive HTTP 503. Unchecked, they keep using the site and see the message below as a banner. This preference is kept when you turn maintenance off, so the next time you turn it on the same choice applies.'); ?>
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <label for="maintenance_message"><?php _e('Message'); ?></label>
+                        <textarea id="maintenance_message" name="maintenance_message" rows="4" cols="60"
+                                  maxlength="<?php echo (int)OSC_MAINTENANCE_MESSAGE_MAX; ?>"><?php
+                            echo osc_esc_html($message); ?></textarea>
+                        <div class="help-box">
+                            <?php _e('Shown on the banner, and on the 503 page when lockout is on. Plain text only (HTML is stripped). Leave blank for the default copy.'); ?>
+                        </div>
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-submit"><?php echo osc_esc_html(__('Save settings')); ?></button>
+                    </div>
+                </div>
+            </fieldset>
+        </form>
     </div>
-    <!-- /settings form -->
 </div>
 <?php osc_current_admin_theme_path('parts/footer.php'); ?>

--- a/oc-admin/themes/modern/tools/system-info.php
+++ b/oc-admin/themes/modern/tools/system-info.php
@@ -602,12 +602,21 @@ define('OSC_DEBUG_LOG', true);</pre>
                     );
 
                     if ($maintenance) {
-                        oscsi_row(
-                            'warn', $CHECK,
-                            __('Maintenance mode'),
-                            sprintf(__('The site is in maintenance mode — visitors see the maintenance page. Remove the %s file to bring it back.'), '<code>.maintenance</code>'),
-                            __('on')
-                        );
+                        if (osc_maintenance_lockout_enabled()) {
+                            oscsi_row(
+                                'warn', $CHECK,
+                                __('Maintenance mode'),
+                                sprintf(__('The site is in maintenance mode — visitors see the maintenance page (HTTP 503). Remove the %s file to bring it back.'), '<code>.maintenance</code>'),
+                                __('on, locked')
+                            );
+                        } else {
+                            oscsi_row(
+                                'warn', $CHECK,
+                                __('Maintenance mode'),
+                                sprintf(__('Maintenance mode is on, but the public site is not blocked. Visitors can still use the site and see a banner. Remove the %s file to hide it, or enable lockout under Tools → Maintenance.'), '<code>.maintenance</code>'),
+                                __('on, banner only')
+                            );
+                        }
                     }
 
                     oscsi_row(

--- a/oc-includes/osclass/classes/controller/admin/CAdminTools.php
+++ b/oc-includes/osclass/classes/controller/admin/CAdminTools.php
@@ -275,6 +275,7 @@ class CAdminTools extends AdminSecBaseModel
                     $maintenance_file = osc_base_path() . '.maintenance';
                     $fileHandler      = @fopen($maintenance_file, 'wb');
                     if ($fileHandler) {
+                        fclose($fileHandler);
                         osc_add_flash_ok_message(_m('Maintenance mode is ON'), 'admin');
                     } else {
                         osc_add_flash_error_message(
@@ -282,7 +283,6 @@ class CAdminTools extends AdminSecBaseModel
                             'admin'
                         );
                     }
-                    fclose($fileHandler);
                     $this->redirectTo(osc_admin_base_url(true) . '?page=tools&action=maintenance');
                 } elseif ($mode === 'off') {
                     osc_csrf_check();
@@ -295,6 +295,23 @@ class CAdminTools extends AdminSecBaseModel
                             'admin'
                         );
                     }
+                    $this->redirectTo(osc_admin_base_url(true) . '?page=tools&action=maintenance');
+                } elseif ($mode === 'save') {
+                    osc_csrf_check();
+                    osc_set_preference(
+                        OSC_MAINTENANCE_PREF_LOCKOUT,
+                        Params::getParam('maintenance_lockout') ? '1' : '0',
+                        OSC_MAINTENANCE_PREF_SECTION,
+                        'BOOLEAN'
+                    );
+                    osc_set_preference(
+                        OSC_MAINTENANCE_PREF_MESSAGE,
+                        osc_sanitize_maintenance_message(Params::getParam('maintenance_message')),
+                        OSC_MAINTENANCE_PREF_SECTION,
+                        'STRING'
+                    );
+                    osc_reset_preferences();
+                    osc_add_flash_ok_message(_m('Maintenance settings saved'), 'admin');
                     $this->redirectTo(osc_admin_base_url(true) . '?page=tools&action=maintenance');
                 }
                 $this->doView('tools/maintenance.php');

--- a/oc-includes/osclass/functions.php
+++ b/oc-includes/osclass/functions.php
@@ -894,12 +894,20 @@ osc_add_hook('cron_hourly', 'osc_expire_premium_items');
 
 function osc_show_maintenance()
 {
-    if (defined('__OSC_MAINTENANCE__')) { ?>
+    if (defined('__OSC_MAINTENANCE__')) {
+        // Lockout on: only admins reach this bar, so tell them the public site
+        // is down. Lockout off: everyone sees the (escaped) visitor message.
+        if (osc_maintenance_lockout_enabled()) {
+            $maintenanceBarText = __('Maintenance mode is on — only signed-in admins can see the site right now.');
+        } else {
+            $maintenanceBarText = osc_maintenance_visitor_message();
+        }
+        ?>
         <div id="osc-maintenance-bar" role="status">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                 <path d="M14.7 6.3a4 4 0 0 1-5.4 5.2l-4.6 4.6a1.5 1.5 0 0 1-2.1-2.1l4.6-4.6a4 4 0 0 1 5.2-5.4l-2.3 2.3 1.4 1.4 2.3-2.3q.5.4.9 1Z" stroke="#7a6716" stroke-width="1.6" fill="none" stroke-linejoin="round"/>
             </svg>
-            <?php _e('Maintenance mode is on — only signed-in admins can see the site right now.'); ?>
+            <?php echo nl2br(osc_esc_html($maintenanceBarText), false); ?>
         </div>
         <style>
             #osc-maintenance-bar {

--- a/oc-includes/osclass/functions.php
+++ b/oc-includes/osclass/functions.php
@@ -894,42 +894,66 @@ osc_add_hook('cron_hourly', 'osc_expire_premium_items');
 
 function osc_show_maintenance()
 {
-    if (defined('__OSC_MAINTENANCE__')) {
-        // Lockout on: only admins reach this bar, so tell them the public site
-        // is down. Lockout off: everyone sees the (escaped) visitor message.
-        if (osc_maintenance_lockout_enabled()) {
-            $maintenanceBarText = __('Maintenance mode is on — only signed-in admins can see the site right now.');
-        } else {
-            $maintenanceBarText = osc_maintenance_visitor_message();
-        }
-        ?>
-        <div id="osc-maintenance-bar" role="status">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M14.7 6.3a4 4 0 0 1-5.4 5.2l-4.6 4.6a1.5 1.5 0 0 1-2.1-2.1l4.6-4.6a4 4 0 0 1 5.2-5.4l-2.3 2.3 1.4 1.4 2.3-2.3q.5.4.9 1Z" stroke="#7a6716" stroke-width="1.6" fill="none" stroke-linejoin="round"/>
-            </svg>
-            <?php echo nl2br(osc_esc_html($maintenanceBarText), false); ?>
-        </div>
-        <style>
-            #osc-maintenance-bar {
-                width: 100%;
-                text-align: center;
-                padding: 10px 16px;
-                background-color: #fdf4d2;
-                color: #7a6716;
-                border-bottom: 1px solid #ecdca0;
-                font-family: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-                font-size: 13px;
-                font-weight: 500;
-            }
-            #osc-maintenance-bar svg {
-                vertical-align: -3px;
-                margin-inline-end: 8px;
-            }
-        </style>
-    <?php }
+    if (!defined('__OSC_MAINTENANCE__')) {
+        return;
     }
+    // Lockout on: only admins reach this bar, so tell them the public site
+    // is down. Lockout off: everyone sees the (escaped) visitor message.
+    if (osc_maintenance_lockout_enabled()) {
+        $maintenanceBarText = __('Maintenance mode is on — only signed-in admins can see the site right now.');
+    } else {
+        $maintenanceBarText = osc_maintenance_visitor_message();
+    }
+    ?>
+    <div id="osc-maintenance-bar" role="status">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M14.7 6.3a4 4 0 0 1-5.4 5.2l-4.6 4.6a1.5 1.5 0 0 1-2.1-2.1l4.6-4.6a4 4 0 0 1 5.2-5.4l-2.3 2.3 1.4 1.4 2.3-2.3q.5.4.9 1Z" stroke="#7a6716" stroke-width="1.6" fill="none" stroke-linejoin="round"/>
+        </svg>
+        <?php echo nl2br(osc_esc_html($maintenanceBarText), false); ?>
+    </div>
+    <style>
+        #osc-maintenance-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 10000;
+            box-sizing: border-box;
+            width: 100%;
+            text-align: center;
+            padding: 10px 16px;
+            background-color: #fdf4d2;
+            color: #7a6716;
+            border-bottom: 1px solid #ecdca0;
+            font-family: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            font-size: 13px;
+            font-weight: 500;
+        }
+        /* After the footer script prepends the bar, drop fixed so it sits in flow. */
+        body > #osc-maintenance-bar {
+            position: relative;
+            z-index: auto;
+        }
+        #osc-maintenance-bar svg {
+            vertical-align: -3px;
+            margin-inline-end: 8px;
+        }
+    </style>
+    <script>
+        (function () {
+            var bar = document.getElementById('osc-maintenance-bar');
+            if (bar && document.body) {
+                document.body.insertBefore(bar, document.body.firstChild);
+            }
+        })();
+    </script>
+    <?php
+}
 
-osc_add_hook('header', 'osc_show_maintenance');
+// Themes run `header` inside <head> (PACKAGE-SPEC). This bar is markup, so it
+// belongs on `footer`, the required hook at the end of <body>. The script
+// above then prepends it as body's first child so it sits in flow at the top.
+osc_add_hook('footer', 'osc_show_maintenance');
 
 function osc_meta_generator()
 {

--- a/oc-includes/osclass/helpers/hMaintenance.php
+++ b/oc-includes/osclass/helpers/hMaintenance.php
@@ -1,0 +1,169 @@
+<?php
+/*
+ * This file is part of Shopclass (Mindstellar).
+ * Copyright (c) 2014 Osclass (original work, licensed under the Apache License 2.0)
+ * Copyright (c) 2021-2026 Mindstellar Community
+ *
+ * Distributed under the GNU General Public License v3.0 or later. The original
+ * Osclass code it derives from was licensed under the Apache License 2.0.
+ * See LICENSE (GPL-3.0) and LICENSE-APACHE (Apache-2.0).
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Maintenance-mode helpers.
+ *
+ * The `.maintenance` file is still the on/off switch. Whether that switch
+ * 503s the public site is a separate preference, defaulting on so existing
+ * installs and the upgrade path that touches the file keep locking visitors
+ * out. The banner (and the 503 page) can show a short admin-written message.
+ *
+ * @package    Shopclass
+ * @subpackage Helpers
+ */
+
+/** Preference section (core `t_preference.s_section`). */
+const OSC_MAINTENANCE_PREF_SECTION = 'osclass';
+
+/** BOOLEAN preference: public HTTP 503 while `.maintenance` exists. */
+const OSC_MAINTENANCE_PREF_LOCKOUT = 'maintenance_lockout';
+
+/** STRING preference: plain-text banner / 503 copy. */
+const OSC_MAINTENANCE_PREF_MESSAGE = 'maintenance_message';
+
+/** Stored message is trimmed, tags stripped, then cut to this length. */
+const OSC_MAINTENANCE_MESSAGE_MAX = 500;
+
+/**
+ * Whether a stored lockout preference means "503 the public site".
+ *
+ * Missing, null, false, or '' is on. Only an explicit `'0'` (or integer 0)
+ * turns lockout off. That way a site that has never saved the new checkbox
+ * keeps today's behaviour.
+ *
+ * Pure: no database. Safe to call from characterization tests.
+ *
+ * @param mixed $value Preference value, or null if unset.
+ *
+ * @return bool
+ */
+function osc_maintenance_lockout_from_pref($value)
+{
+    if ($value === null || $value === false) {
+        return true;
+    }
+    if (is_array($value) || is_object($value)) {
+        return true;
+    }
+
+    return trim((string)$value) !== '0';
+}
+
+/**
+ * Strip tags, trim, and cap the admin-written maintenance message.
+ *
+ * Pure: no database. HTML is not stored; callers escape on output.
+ *
+ * @param mixed $raw Posted or stored value.
+ *
+ * @return string
+ */
+function osc_sanitize_maintenance_message($raw)
+{
+    if (!is_string($raw) && !is_int($raw) && !is_float($raw)) {
+        return '';
+    }
+    $s = trim(strip_tags((string)$raw));
+    if ($s === '') {
+        return '';
+    }
+    $max = OSC_MAINTENANCE_MESSAGE_MAX;
+    if (function_exists('mb_strlen') && mb_strlen($s, 'UTF-8') > $max) {
+        return mb_substr($s, 0, $max, 'UTF-8');
+    }
+    if (strlen($s) > $max) {
+        return substr($s, 0, $max);
+    }
+
+    return $s;
+}
+
+/**
+ * Should this request be answered with HTTP 503?
+ *
+ * False when there is no `.maintenance` file, the visitor is a signed-in
+ * admin, the SAPI is CLI (so `php index.php -p cron` still runs), or lockout
+ * has been turned off. Pure: no database.
+ *
+ * @param bool $fileExists      `.maintenance` is present at the install root.
+ * @param bool $lockoutEnabled  osc_maintenance_lockout_from_pref() answer.
+ * @param bool $isAdmin         Signed-in oc-admin user.
+ * @param bool $isCli           PHP_SAPI === 'cli' / the CLI constant.
+ *
+ * @return bool
+ */
+function osc_maintenance_should_lockout_request($fileExists, $lockoutEnabled, $isAdmin, $isCli)
+{
+    if (!$fileExists || $isCli || $isAdmin) {
+        return false;
+    }
+
+    return (bool)$lockoutEnabled;
+}
+
+/**
+ * Whether public visitors should get HTTP 503 while `.maintenance` exists.
+ *
+ * @return bool
+ */
+function osc_maintenance_lockout_enabled()
+{
+    if (!function_exists('osc_get_preference')) {
+        return true;
+    }
+
+    return osc_maintenance_lockout_from_pref(
+        osc_get_preference(OSC_MAINTENANCE_PREF_LOCKOUT, OSC_MAINTENANCE_PREF_SECTION)
+    );
+}
+
+/**
+ * Default visitor copy when the admin has not saved a message.
+ *
+ * @return string
+ */
+function osc_maintenance_default_message()
+{
+    $title = function_exists('osc_page_title') ? (string)osc_page_title() : '';
+    if ($title !== '' && function_exists('__')) {
+        return sprintf(
+            __('%s is undergoing maintenance right now. We\'re making some improvements and will be back shortly — thanks for your patience.'),
+            $title
+        );
+    }
+
+    return "We're making some improvements and will be back shortly — thanks for your patience.";
+}
+
+/**
+ * Plain-text message shown on the public banner and the 503 page.
+ *
+ * Empty stored preference falls back to osc_maintenance_default_message().
+ *
+ * @return string
+ */
+function osc_maintenance_visitor_message()
+{
+    $saved = '';
+    if (function_exists('osc_get_preference')) {
+        $saved = osc_sanitize_maintenance_message(
+            osc_get_preference(OSC_MAINTENANCE_PREF_MESSAGE, OSC_MAINTENANCE_PREF_SECTION)
+        );
+    }
+    if ($saved !== '') {
+        return $saved;
+    }
+
+    return osc_maintenance_default_message();
+}

--- a/oc-load.php
+++ b/oc-load.php
@@ -57,6 +57,7 @@ OsclassErrors::newInstance()->register();
 require_once LIB_PATH . 'osclass/helpers/hDatabaseInfo.php';
 require_once LIB_PATH . 'osclass/helpers/hDatabase.php';
 require_once LIB_PATH . 'osclass/helpers/hPreference.php';
+require_once LIB_PATH . 'osclass/helpers/hMaintenance.php';
 // check if Shopclass is installed
 if (!Preference::newInstance()->get('osclass_installed')) {
     osc_die(

--- a/tests/maintenance-mode.php
+++ b/tests/maintenance-mode.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * This file is part of Shopclass (Mindstellar).
+ * Copyright (c) 2021-2026 Mindstellar Community
+ *
+ * Distributed under the GNU General Public License v3.0 or later. See LICENSE.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Maintenance lockout defaults on (missing pref ⇒ 503) so existing sites and
+ * the upgrade path that touches `.maintenance` keep taking the public site
+ * down. Only an explicit `'0'` is a soft banner. The saved message is plain
+ * text, not HTML.
+ *
+ * DB-free. Usage:  php tests/maintenance-mode.php
+ */
+
+require_once __DIR__ . '/../oc-includes/osclass/helpers/hMaintenance.php';
+require_once __DIR__ . '/lib/harness.php';
+
+$GLOBALS['okCount']    = 0;
+$GLOBALS['failCount']  = 0;
+$GLOBALS['failLabels'] = array();
+
+harness_section('lockout pref defaults on');
+check('null is on', osc_maintenance_lockout_from_pref(null) === true);
+check('false is on', osc_maintenance_lockout_from_pref(false) === true);
+check('empty string is on', osc_maintenance_lockout_from_pref('') === true);
+check('whitespace is on', osc_maintenance_lockout_from_pref('  ') === true);
+check('1 is on', osc_maintenance_lockout_from_pref('1') === true);
+check('true string is on', osc_maintenance_lockout_from_pref('true') === true);
+check('explicit 0 is off', osc_maintenance_lockout_from_pref('0') === false);
+check('integer 0 is off', osc_maintenance_lockout_from_pref(0) === false);
+check('padded 0 is off', osc_maintenance_lockout_from_pref(' 0 ') === false);
+
+harness_section('503 vs banner vs CLI');
+check(
+    'lockout 503s the public site',
+    osc_maintenance_should_lockout_request(true, true, false, false) === true
+);
+check(
+    'soft banner does not 503',
+    osc_maintenance_should_lockout_request(true, false, false, false) === false
+);
+check(
+    'admins never 503',
+    osc_maintenance_should_lockout_request(true, true, true, false) === false
+);
+check(
+    'CLI cron is not 503d',
+    osc_maintenance_should_lockout_request(true, true, false, true) === false
+);
+check(
+    'no file means no lockout',
+    osc_maintenance_should_lockout_request(false, true, false, false) === false
+);
+
+harness_section('message sanitizer');
+pin('plain text kept', 'Back soon', osc_sanitize_maintenance_message('  Back soon  '));
+pin('tags stripped', 'Back soon', osc_sanitize_maintenance_message('<b>Back soon</b>'));
+// strip_tags() removes the tags, not the text between them. XSS is stopped
+// at render by osc_esc_html(), not by trying to parse script contents here.
+pin('script tags stripped, text kept', 'alert(1)hello', osc_sanitize_maintenance_message('<script>alert(1)</script>hello'));
+pin('array rejected', '', osc_sanitize_maintenance_message(array('x')));
+pin('null rejected', '', osc_sanitize_maintenance_message(null));
+$long = str_repeat('a', OSC_MAINTENANCE_MESSAGE_MAX + 20);
+pin(
+    'capped at ' . OSC_MAINTENANCE_MESSAGE_MAX,
+    OSC_MAINTENANCE_MESSAGE_MAX,
+    strlen(osc_sanitize_maintenance_message($long))
+);
+pin('empty after tags', '', osc_sanitize_maintenance_message('<p></p>'));
+
+exit(harness_result());


### PR DESCRIPTION
## Why

`.maintenance` is still the only on/off switch. Today that file always 503s the public site. That is the right default for an upgrade (core already `touch`es the file) and for anyone who already relies on lockout. This PR adds a second, optional layer: keep the site up and show a banner whose text the admin edits.

Nothing site-specific, no extra routes, no HTML in the banner.

## Logic

1. **File on/off.** Tools → Maintenance still creates or removes `.maintenance`. That is unchanged.
2. **Lockout defaults on.** Missing/empty `maintenance_lockout` reads as on. Existing installs and the upgrade path that writes the file still 503 visitors. Only an explicit `0` (unchecked checkbox, saved) is the soft mode.
3. **Soft mode.** File present + lockout off → HTTP 200 for everyone. `__OSC_MAINTENANCE__` is defined so the header bar renders. The bar shows the saved message (escaped); if the message is blank, the previous default copy (with the site title) is used.
4. **Hard mode.** File present + lockout on → public HTTP 503, same as today. Theme `maintenance.php` still wins if the theme ships one; otherwise `osc_die()` uses the same (escaped) message. Admins skip the 503 and see the bar, with copy that says only signed-in admins can see the site.
5. **Admins never 503.** `osc_is_admin_user_logged_in()` still bypasses lockout.
6. **CLI never 503.** `php index.php -p cron` is not an admin session, so today it would hit the 503 path during lockout and cron would not run. CLI is exempted. `oc-cli.php` never went through `index.php` and is unchanged.
7. **Plain text only.** The saved message is trimmed, `strip_tags`, max 500 characters. HTML is not stored. Output goes through `osc_esc_html` (and `nl2br`) on the banner and on the 503 page.
8. **fclose.** `fopen` of `.maintenance` only `fclose`s a real handle. PHP 8 type-errors if `fopen` failed and we still closed `false`.

Prefs: section `osclass`, `maintenance_lockout` BOOLEAN, `maintenance_message` STRING. The 503/banner decision is a pair of pure helpers so the default-on lockout and the sanitizer can be pinned without a database (`tests/maintenance-mode.php`).

## How to test

- Tools → Maintenance → Enable. Incognito: HTTP 503. Admin session: site works, yellow bar (admins-only copy).
- Uncheck **Block the public site**, save a short message. Incognito: HTTP 200 + banner with that text. `<script>` in the message must not run.
- Clear the message and save: default copy comes back.
- `php index.php -p cron -t hourly` while `.maintenance` exists and lockout is on: cron still runs (no 503).
- Disable maintenance: banner gone, site as usual. Re-enable: the last lockout/message choice is still there.

Made with [Cursor](https://cursor.com)