### PR TITLE
fix: account deletion is a CSRF POST, not a GET with the secret in the URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,10 @@ jobs:
       # order there is silent -- the entry renders, just under the log-out row.
       - name: Account menu order
         run: php tests/user-menu-order.php
+      # GET ?page=user&action=delete&id=&secret= used to remove the account as soon
+      # as the page was requested. The confirm view must not call deleteUser.
+      - name: Account delete is POST
+        run: php tests/user-delete-get.php
       # An unrouted settings action does not error -- it renders a different settings page
       # and discards the post, so the only symptom is preferences that never save.
       - name: Admin settings routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ with too: every listing index now has its own description and a single canonical
 
 ### Security
 
+- **Deleting an account was a GET with the account id and secret in the URL.**
+  `?page=user&action=delete&id=…&secret=…` removed the signed-in account as soon as
+  the page was requested — a mail scanner, a prefetch, or a leaked referrer was
+  enough. GET now shows a confirm form; the deletion is POST `delete_post` with a
+  CSRF token and the current password. Existing theme links that still carry id and
+  secret land on the confirm page and no longer delete. Themes may ship
+  `user-delete_account.php`; core falls back to its own view when they do not.
 - **A listing description was stored exactly as submitted on sites using the rich editor.**
   Params' XSS check strips every tag, so it is switched off wherever a rich editor is in
   use, and nothing replaced it — a script in a description ran for every visitor who opened

--- a/oc-content/languages/messages.pot
+++ b/oc-content/languages/messages.pot
@@ -323,6 +323,10 @@ msgstr ""
 msgid "Buying credits is not available on this site."
 msgstr ""
 
+#: oc-includes/osclass/gui/user-delete_account-content.php
+msgid "Cancel"
+msgstr ""
+
 #: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Cancelled"
 msgstr ""
@@ -501,6 +505,15 @@ msgstr ""
 #: oc-includes/osclass/gui/billing/orders-content.php
 #: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Date"
+msgstr ""
+
+#: oc-includes/osclass/gui/user-delete_account-content.php
+msgid "Delete my account"
+msgstr ""
+
+#: oc-includes/osclass/gui/user-delete_account-content.php
+#: oc-includes/osclass/gui/user-delete_account.php
+msgid "Delete your account"
 msgstr ""
 
 #: oc-includes/osclass/classes/controller/admin/CAdminItems.php
@@ -1137,6 +1150,10 @@ msgstr ""
 
 #: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Paid"
+msgstr ""
+
+#: oc-includes/osclass/gui/user-delete_account-content.php
+msgid "Password"
 msgstr ""
 
 #: oc-includes/osclass/classes/controller/CWebLogin.php
@@ -2055,6 +2072,13 @@ msgstr ""
 
 #: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "This listing doesn't exist"
+msgstr ""
+
+#: oc-includes/osclass/gui/user-delete_account-content.php
+msgid ""
+"This page has not deleted the account yet. Enter your password and click "
+"Delete my account. Your listings and messages will be removed. This cannot "
+"be undone."
 msgstr ""
 
 #: oc-includes/osclass/classes/controller/CWebLogin.php

--- a/oc-includes/osclass/classes/controller/CWebUser.php
+++ b/oc-includes/osclass/classes/controller/CWebUser.php
@@ -312,10 +312,8 @@ class CWebUser extends WebSecBaseModel
                 break;
             case 'export':
                 // A copy of everything held about the person, for their own request.
-                // Gated exactly as 'delete' below is — signed in, and the id and secret
-                // in the link both matching the session — because it hands out the same
-                // data that action destroys, and inventing a second rule for that would
-                // mean two things to keep right instead of one.
+                // Signed in, and the id and secret in the link both matching the session,
+                // because it hands out the same data that deleting the account destroys.
                 $id     = Params::getParamInt('id');
                 $secret = Params::getParamString('secret');
                 if (!osc_is_web_user_logged_in()) {
@@ -351,40 +349,67 @@ class CWebUser extends WebSecBaseModel
                 echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
                 exit;
             case 'delete':
-                $id     = Params::getParam('id');
-                $secret = Params::getParam('secret');
-                if (osc_is_web_user_logged_in()) {
-                    $user = User::newInstance()->findByPrimaryKey(osc_logged_user_id());
-                    osc_run_hook('before_user_delete', $user);
-                    View::newInstance()->_exportVariableToView('user', $user);
-                    if (!empty($user) && osc_logged_user_id() == $id
-                        && $secret == $user['s_secret']
-                    ) {
-                        try {
-                            User::newInstance()->deleteUser(osc_logged_user_id());
-                        } catch (Exception $e) {
-                            trigger_error($e->getMessage(), E_USER_WARNING);
-                        }
-
-                        Session::newInstance()->_drop('userId');
-                        Session::newInstance()->_drop('userName');
-                        Session::newInstance()->_drop('userEmail');
-                        Session::newInstance()->_drop('userPhone');
-
-                        Cookie::newInstance()->pop('oc_userId');
-                        Cookie::newInstance()->pop('oc_userSecret');
-                        Cookie::newInstance()->set();
-
-                        osc_add_flash_ok_message(_m('Your account have been deleted'));
-                        $this->redirectTo(osc_base_url());
-                    } else {
-                        osc_add_flash_error_message(_m('Oops! you can not do that'));
-                        $this->redirectTo(osc_user_dashboard_url());
-                    }
-                } else {
+                // GET must not delete. Older themes still point here with id and
+                // secret in the query string; those land on the confirm form and
+                // the query values are ignored. Mail scanners and prefetchers
+                // that only GET therefore cannot remove the account.
+                $user = User::newInstance()->findByPrimaryKey(osc_logged_user_id());
+                if (empty($user)) {
                     osc_add_flash_error_message(_m('Oops! you can not do that'));
-                    $this->redirectTo(osc_base_url());
+                    $this->redirectTo(osc_user_login_url());
+                    break;
                 }
+                $this->_exportVariableToView('user', $user);
+                $this->doView('user-delete_account.php');
+                break;
+            case 'delete_post':
+                osc_csrf_check();
+                $userId = (int) osc_logged_user_id();
+                $user   = User::newInstance()->findByPrimaryKey($userId);
+                if (empty($user) || $userId < 1) {
+                    osc_add_flash_error_message(_m('Oops! you can not do that'));
+                    $this->redirectTo(osc_user_login_url());
+                    break;
+                }
+
+                $password = Params::getParam('password', false, false);
+                if ($password === '') {
+                    osc_add_flash_warning_message(_m('Password cannot be blank'));
+                    $this->redirectTo(osc_user_delete_url());
+                    break;
+                }
+                if (!osc_verify_password($password, $user['s_password'])) {
+                    osc_add_flash_error_message(_m("Current password doesn't match"));
+                    $this->redirectTo(osc_user_delete_url());
+                    break;
+                }
+
+                osc_run_hook('before_user_delete', $user);
+                try {
+                    User::newInstance()->deleteUser($userId);
+                } catch (Exception $e) {
+                    trigger_error($e->getMessage(), E_USER_WARNING);
+                    osc_add_flash_error_message(_m('Oops! you can not do that'));
+                    $this->redirectTo(osc_user_delete_url());
+                    break;
+                }
+
+                Session::newInstance()->_drop('userId');
+                Session::newInstance()->_drop('userName');
+                Session::newInstance()->_drop('userEmail');
+                Session::newInstance()->_drop('userPhone');
+                Session::newInstance()->_dropEphemeral('userId');
+                Session::newInstance()->_dropEphemeral('userName');
+                Session::newInstance()->_dropEphemeral('userEmail');
+                Session::newInstance()->_dropEphemeral('userPhone');
+                View::newInstance()->_erase('_loggedUser');
+
+                Cookie::newInstance()->pop('oc_userId');
+                Cookie::newInstance()->pop('oc_userSecret');
+                Cookie::newInstance()->set();
+
+                osc_add_flash_ok_message(_m('Your account have been deleted'));
+                $this->redirectTo(osc_base_url());
                 break;
         }
     }
@@ -464,9 +489,31 @@ class CWebUser extends WebSecBaseModel
     public function doView($file)
     {
         osc_run_hook('before_html');
-        osc_current_web_theme_path($file);
+        if ($file === 'user-delete_account.php' && !$this->themeProvides($file)) {
+            $this->doFallbackDeleteView();
+        } else {
+            osc_current_web_theme_path($file);
+        }
         Session::newInstance()->_clearVariables();
         osc_run_hook('after_html');
+    }
+
+    /**
+     * Whether the active theme ships $file itself. Not osc_current_web_theme_path()'s
+     * walk onto a parent or storefront: those have never heard of this view and would
+     * render blank instead of the core fallback.
+     */
+    private function themeProvides(string $file): bool
+    {
+        return file_exists(WebThemes::newInstance()->getCurrentThemePath() . $file);
+    }
+
+    private function doFallbackDeleteView(): void
+    {
+        $path = osc_base_path() . 'oc-includes/osclass/gui/user-delete_account.php';
+        if (file_exists($path)) {
+            require $path;
+        }
     }
 }
 

--- a/oc-includes/osclass/classes/themes/WebThemes.php
+++ b/oc-includes/osclass/classes/themes/WebThemes.php
@@ -43,6 +43,7 @@ class WebThemes extends Themes
         'user-change_email',
         'user-change_password',
         'user-dashboard',
+        'user-delete_account',
         'user-forgot_password',
         'user-items',
         'user-login',

--- a/oc-includes/osclass/gui/user-delete_account-content.php
+++ b/oc-includes/osclass/gui/user-delete_account-content.php
@@ -1,0 +1,36 @@
+<?php
+if (!defined('ABS_PATH')) {
+    exit('Direct access is not allowed.');
+}
+
+/*
+ * This file is part of Shopclass (Mindstellar).
+ * Copyright (c) 2021-2026 Mindstellar Community
+ *
+ * Distributed under the GNU General Public License v3.0 or later. See LICENSE.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Account-delete confirm form -- markup only. CSRF is injected on shutdown
+ * for forms that are not marked nocsrf. The POST is delete_post; this GET
+ * page does not delete anything.
+ */
+?>
+<section class="osc-user-delete-account">
+    <h1><?php echo osc_esc_html(_m('Delete your account')); ?></h1>
+    <p><?php echo osc_esc_html(_m('This page has not deleted the account yet. Enter your password and click Delete my account. Your listings and messages will be removed. This cannot be undone.')); ?></p>
+    <form action="<?php echo osc_esc_html(osc_base_url(true)); ?>" method="post">
+        <input type="hidden" name="page" value="user" />
+        <input type="hidden" name="action" value="delete_post" />
+        <p>
+            <label for="osc-delete-account-password"><?php echo osc_esc_html(_m('Password')); ?></label>
+            <input id="osc-delete-account-password" type="password" name="password" autocomplete="current-password" required />
+        </p>
+        <p>
+            <button type="submit"><?php echo osc_esc_html(_m('Delete my account')); ?></button>
+            <a href="<?php echo osc_esc_html(osc_user_profile_url()); ?>"><?php echo osc_esc_html(_m('Cancel')); ?></a>
+        </p>
+    </form>
+</section>

--- a/oc-includes/osclass/gui/user-delete_account.php
+++ b/oc-includes/osclass/gui/user-delete_account.php
@@ -1,0 +1,48 @@
+<?php
+if (!defined('ABS_PATH')) {
+    exit('Direct access is not allowed.');
+}
+
+/*
+ * This file is part of Shopclass (Mindstellar).
+ * Copyright (c) 2021-2026 Mindstellar Community
+ *
+ * Distributed under the GNU General Public License v3.0 or later. See LICENSE.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Core's fallback account-delete page -- rendered only when the active theme
+ * has no user-delete_account.php of its own. Wraps user-delete_account-content.php
+ * in the theme chrome when header.php and footer.php exist. See CWebUser::doView().
+ */
+
+$themePath = WebThemes::newInstance()->getCurrentThemePath();
+$hasChrome = file_exists($themePath . 'header.php') && file_exists($themePath . 'footer.php');
+
+if ($hasChrome) {
+    osc_current_web_theme_path('header.php');
+} else {
+    ?><!doctype html>
+<html lang="<?php echo osc_esc_html(str_replace('_', '-', osc_current_user_locale())); ?>">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?php echo osc_esc_html(_m('Delete your account')); ?></title>
+<style>html,body{margin:0;padding:0;background:#f7f9fb;}</style>
+</head>
+<body>
+    <?php
+}
+
+require __DIR__ . '/user-delete_account-content.php';
+
+if ($hasChrome) {
+    osc_current_web_theme_path('footer.php');
+} else {
+    ?>
+</body>
+</html>
+<?php
+}

--- a/oc-includes/osclass/helpers/hDefines.php
+++ b/oc-includes/osclass/helpers/hDefines.php
@@ -661,10 +661,9 @@ function osc_user_alerts_url()
 /**
  * Link that downloads the signed-in person a copy of their own data.
  *
- * Carries the account id and its secret, the same two the delete link carries and the
- * same two the action re-checks against the session. Returns '' when nobody is signed
- * in, so a theme can print it unconditionally and get nothing rather than a link that
- * cannot work.
+ * Carries the account id and its secret, and the action re-checks both against
+ * the session. Returns '' when nobody is signed in, so a theme can print it
+ * unconditionally and get nothing rather than a link that cannot work.
  *
  * @return string
  */
@@ -681,6 +680,24 @@ function osc_user_export_url()
 
     return osc_base_url(true) . '?page=user&action=export&id=' . (int)$user['pk_i_id']
         . '&secret=' . rawurlencode($user['s_secret']);
+}
+
+/**
+ * Confirm page for deleting the signed-in account.
+ *
+ * GET only: it must not carry an id or secret, and it must not delete anything.
+ * The POST that actually deletes is `delete_post` and is not built here.
+ * Returns '' when nobody is signed in.
+ *
+ * @return string
+ */
+function osc_user_delete_url()
+{
+    if (!osc_is_web_user_logged_in()) {
+        return '';
+    }
+
+    return osc_base_url(true) . '?page=user&action=delete';
 }
 
 /**

--- a/scripts/build-i18n.mjs
+++ b/scripts/build-i18n.mjs
@@ -114,7 +114,7 @@ async function extract() {
             }
             const explicitDomain = decode(sDom, dDom);
             const domain = fn === '_m' ? 'messages' : (explicitDomain || DEFAULT_DOMAIN);
-            record(domain, msgid, null, file);
+            record(domain, msgid, null, file.replace(/\\/g, '/'));
         }
 
         for (const m of content.matchAll(CONTEXT_RE)) {
@@ -126,7 +126,7 @@ async function extract() {
             }
             const explicitDomain = decode(sDom, dDom);
             const domain = fn === '_mx' ? 'messages' : (explicitDomain || DEFAULT_DOMAIN);
-            record(domain, msgid, null, file, msgctxt);
+            record(domain, msgid, null, file.replace(/\\/g, '/'), msgctxt);
         }
 
         for (const m of content.matchAll(PLURAL_RE)) {
@@ -137,7 +137,7 @@ async function extract() {
                 continue;
             }
             const domain = fn === '_mn' ? 'messages' : DEFAULT_DOMAIN;
-            record(domain, single, plural, file);
+            record(domain, single, plural, file.replace(/\\/g, '/'));
         }
     }
 }

--- a/tests/user-delete-get.php
+++ b/tests/user-delete-get.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * This file is part of Shopclass (Mindstellar).
+ * Copyright (c) 2021-2026 Mindstellar Community
+ *
+ * Distributed under the GNU General Public License v3.0 or later. See LICENSE.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Pins that account deletion is not a GET with id+secret in the URL.
+ *
+ * The old action deleted as soon as the page was requested. A mail scanner or
+ * a leaked referrer was enough. GET must only render the confirm view; the
+ * mutation is POST delete_post with CSRF and the current password. The helper
+ * that themes should print must not put a secret in the query string.
+ *
+ * DB-free. Usage:  php tests/user-delete-get.php
+ */
+
+require_once __DIR__ . '/lib/harness.php';
+
+$controller = file_get_contents(
+    __DIR__ . '/../oc-includes/osclass/classes/controller/CWebUser.php'
+);
+$defines = file_get_contents(
+    __DIR__ . '/../oc-includes/osclass/helpers/hDefines.php'
+);
+
+harness_section('GET delete does not mutate');
+check(
+    'the GET case exists',
+    (bool)preg_match("/case 'delete':/", $controller)
+);
+preg_match("/case 'delete':(.*?)case 'delete_post':/s", $controller, $get);
+check('GET delete was parsed as its own case', isset($get[1]) && $get[1] !== '');
+check(
+    'GET delete does not call deleteUser',
+    isset($get[1]) && strpos($get[1], 'deleteUser') === false
+);
+check(
+    'GET delete does not read a posted secret',
+    isset($get[1]) && strpos($get[1], "getParam('secret')") === false
+        && strpos($get[1], 'getParamString(\'secret\')') === false
+);
+check(
+    'GET delete renders the confirm view',
+    isset($get[1]) && strpos($get[1], 'user-delete_account.php') !== false
+);
+
+harness_section('POST delete_post is the mutation');
+preg_match("/case 'delete_post':(.*?)private function handleAvatarUpload/s", $controller, $post);
+check('delete_post was parsed', isset($post[1]) && $post[1] !== '');
+check(
+    'delete_post checks CSRF',
+    isset($post[1]) && strpos($post[1], 'osc_csrf_check()') !== false
+);
+check(
+    'delete_post verifies the current password',
+    isset($post[1]) && strpos($post[1], 'osc_verify_password') !== false
+);
+check(
+    'delete_post calls deleteUser',
+    isset($post[1]) && strpos($post[1], 'deleteUser') !== false
+);
+
+harness_section('osc_user_delete_url has no secret');
+check(
+    'the helper exists',
+    (bool)preg_match('/function osc_user_delete_url\(\)/', $defines)
+);
+$start = strpos($defines, 'function osc_user_delete_url()');
+$end   = strpos($defines, 'function osc_user_unsubscribe_alert_url');
+$helper = ($start !== false && $end !== false && $end > $start)
+    ? substr($defines, $start, $end - $start)
+    : '';
+check('the helper body was parsed', $helper !== '');
+check(
+    'the helper does not put secret in the URL',
+    $helper !== '' && !preg_match("/action=delete.*secret/", $helper)
+        && strpos($helper, '&secret') === false
+        && strpos($helper, "s_secret") === false
+);
+check(
+    'the helper does not put id in the URL',
+    $helper !== '' && strpos($helper, 'id=') === false
+);
+check(
+    'the helper points at the GET confirm action',
+    $helper !== '' && strpos($helper, 'action=delete') !== false
+        && strpos($helper, 'delete_post') === false
+);
+
+exit(harness_result());


### PR DESCRIPTION
## Summary
- `?page=user&action=delete&id=&secret=` used to delete the signed-in account on GET. A mail scanner, prefetch, or leaked referrer was enough.
- GET now shows a confirm form. The mutation is POST `delete_post` with a CSRF token and the current password. The session user is used; query id/secret are ignored.
- Existing theme links that still carry id and secret land on the confirm page and no longer delete. Themes may ship `user-delete_account.php`; core falls back to `oc-includes/osclass/gui/` when they do not.
- `osc_user_delete_url()` is the helper to print (no secret). `.pot` refs stay POSIX on Windows so `npm run i18n` does not rewrite every path.

## Test plan
- [ ] `php tests/user-delete-get.php`
- [ ] Signed in, open `?page=user&action=delete&id=YOUR_ID&secret=YOUR_SECRET` (old theme link): confirm page, account still exists
- [ ] Submit without password: stays on confirm, not deleted
- [ ] Submit with wrong password: error, not deleted
- [ ] Submit with CSRF + correct password: account gone, signed out, flash on home
- [ ] GET `delete_post` does not delete
- [ ] Theme without `user-delete_account.php` still renders the core fallback inside header/footer